### PR TITLE
Apply user filter before recursively reading directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,19 @@ Call the prompt:
       name: 'path',
       pathFilter: (isDirectory, nodePath) => isDirectory,
         // pathFilter :: (Bool, String) -> Bool
-        // pathFilter allows you to filter the fs entries     returned to the user
+        // pathFilter allows you to filter the fs entries
+        //   returned to the user. Returning false here
+        //   will prevent the directory from being scanned
+        //   unless you provide a separate scanFilter
+        //   function below.
       scanFilter: (isDirectory, nodePath) => isDirectory,
         // scanFilter :: (Bool, String) -> Bool
-        // scanFilter allows you to control where this plugin searches for files, and is applied only when reading the directory. As an example, for better performance, you might want to filter out `node-modules` using this function.
+        // scanFilter allows you to control where this
+        //   plugin searches for files, and is applied
+        //   only when reading the directory. As an
+        //   example, for better performance, you might
+        //   want to filter out `node-modules` using this
+        //   function.
       rootPath: 'app',
         // rootPath :: String
         // Root search directory

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # inquirer-fuzzy-path
 
-Fuzzy file/directory search and select prompt for Inquirer.js 
+Fuzzy file/directory search and select prompt for Inquirer.js
 
 ![inquirer-fuzzy-path demo](https://raw.githubusercontent.com/adelsz/inquirer-fuzzy-path/master/recording.gif)
 
@@ -19,7 +19,10 @@ Call the prompt:
       name: 'path',
       pathFilter: (isDirectory, nodePath) => isDirectory,
         // pathFilter :: (Bool, String) -> Bool
-        // pathFilter allows to filter FS nodes by type and path
+        // pathFilter allows you to filter the fs entries     returned to the user
+      scanFilter: (isDirectory, nodePath) => isDirectory,
+        // scanFilter :: (Bool, String) -> Bool
+        // scanFilter allows you to control where this plugin searches for files, and is applied only when reading the directory. As an example, for better performance, you might want to filter out `node-modules` using this function.
       rootPath: 'app',
         // rootPath :: String
         // Root search directory

--- a/index.js
+++ b/index.js
@@ -23,9 +23,16 @@ function getPaths(rootPath, pattern, pathFilter, scanFilter) {
   async function listNodes(nodePath) {
     try {
       const entries = await readdir(nodePath, { withFileTypes: true });
-      const nodes = entries
-        .filter(entry => typeof entry === 'string' || scanFilter(entry.isDirectory(), entry.name))
-        .map(entry => entry.name);
+
+      let nodes
+      // Detect if on node > 10.10 which supports readdir withFileTypes
+      if (typeof entries[0] === 'string') {
+        nodes = entries
+      } else {
+        nodes = entries
+          .filter(entry => scanFilter(entry.isDirectory(), entry.name))
+          .map(entry => entry.name);
+      }
 
       const currentNode = nodeOption(nodePath, true);
       if (nodes.length > 0) {

--- a/index.js
+++ b/index.js
@@ -56,9 +56,12 @@ class InquirerFuzzyPath extends InquirerAutocomplete {
     const rootPath = question.rootPath || '.';
     const pathFilter = question.pathFilter || (() => true);
     const scanFilter = question.scanFilter || question.pathFilter || (() => true);
-    const questionBase = Object.assign({}, question, {
-      source: (_, pattern) => getPaths(rootPath, pattern, pathFilter, scanFilter),
-    });
+    const questionBase = Object.assign(
+      {},
+      question,
+      {
+        source: (_, pattern) => getPaths(rootPath, pattern, pathFilter, scanFilter),
+      });
     super(questionBase, rl, answers);
   }
 

--- a/index.js
+++ b/index.js
@@ -22,7 +22,11 @@ function getPaths(rootPath, pattern, pathFilter) {
 
   async function listNodes(nodePath) {
     try {
-      const nodes = await readdir(nodePath);
+      const entries = await readdir(nodePath, { withFileTypes: true });
+      const nodes = entries
+        .filter(entry => nodeOption(entry.name, entry.isDirectory()).length > 0)
+        .map(entry => entry.name);
+
       const currentNode = nodeOption(nodePath, true);
       if (nodes.length > 0) {
         const nodex = nodes.map(dirName => listNodes(path.join(nodePath, dirName)));

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ function getPaths(rootPath, pattern, pathFilter, scanFilter) {
     try {
       const entries = await readdir(nodePath, { withFileTypes: true });
       const nodes = entries
-        .filter(entry => scanFilter(entry.isDirectory(), entry.name))
+        .filter(entry => typeof entry === 'string' || scanFilter(entry.isDirectory(), entry.name))
         .map(entry => entry.name);
 
       const currentNode = nodeOption(nodePath, true);


### PR DESCRIPTION
Love this addon!

This is a performance tweak so that time isn't wasted descending into directories that will be filtered out of the prompt later on. This is most noticeable when you are working in a node package with lots of `node_modules` that you want to filter out.

This only works in Node 10.10+, as the `withFileTypes: true` and `fs.Dirent` type were added in this version.