### PR TITLE
adding optional `level` prop to limit the sub-folders scanning depth

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ Call the prompt:
       suggestOnly: false,
         // suggestOnly :: Bool
         // Restrict prompt answer to available choices or use them as suggestions
+      level: 5,
+        // level :: integer
+        // limit the level of sub-folders to scan. Defaults to 3
     }
   ]);
 ```

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ Call the prompt:
       suggestOnly: false,
         // suggestOnly :: Bool
         // Restrict prompt answer to available choices or use them as suggestions
-      level: 5,
-        // level :: integer
+      levels: 5,
+        // levels :: integer
         // limit the level of sub-folders to scan. Defaults to 3
     }
   ]);

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Call the prompt:
         // Restrict prompt answer to available choices or use them as suggestions
       levels: 5,
         // levels :: integer
-        // limit the level of sub-folders to scan. Defaults to 3
+        // limit the levels of sub-folders to scan. Defaults to 3
     }
   ]);
 ```

--- a/index.js
+++ b/index.js
@@ -25,12 +25,12 @@ function getPaths(
 
   async function listNodes(nodePath, levels) {
     try {
-      if (excludePath(nodePath) || levels < 0) {
+      if (excludePath(nodePath)) {
         return [];
       }
       const nodes = await readdir(nodePath);
       const currentNode = (itemType !== 'file' ? [nodePath] : []);
-      if (nodes.length > 0) {
+      if (nodes.length > 0 && levels > 0) {
         const nodesWithPath = nodes.map(
           nodeName => listNodes(path.join(nodePath, nodeName), levels - 1),
         );

--- a/index.js
+++ b/index.js
@@ -16,22 +16,23 @@ function getPaths(
   excludePath,
   itemType,
   defaultItem,
+  levels = 3
 ) {
   const fuzzOptions = {
     pre: style.green.open,
     post: style.green.close,
   };
 
-  async function listNodes(nodePath) {
+  async function listNodes(nodePath, levels) {
     try {
-      if (excludePath(nodePath)) {
+      if (excludePath(nodePath) || levels < 0) {
         return [];
       }
       const nodes = await readdir(nodePath);
       const currentNode = (itemType !== 'file' ? [nodePath] : []);
       if (nodes.length > 0) {
         const nodesWithPath = nodes.map(
-          nodeName => listNodes(path.join(nodePath, nodeName)),
+          nodeName => listNodes(path.join(nodePath, nodeName), levels - 1),
         );
         const subNodes = await Promise.all(nodesWithPath);
         return subNodes.reduce((acc, val) => acc.concat(val), currentNode);
@@ -45,7 +46,7 @@ function getPaths(
     }
   }
 
-  const nodes = listNodes(rootPath);
+  const nodes = listNodes(rootPath, levels);
   const filterPromise = nodes.then(
     (nodeList) => {
       const filteredNodes = fuzzy


### PR DESCRIPTION
When dealing with hundreds of sub folders it becomes very slow.
This PR allows for an optional `level` prop (defaults to 3) to limit the number of levels of sub folders to scan.

fixes: https://github.com/adelsz/inquirer-fuzzy-path/issues/8