### PR TITLE
feat: ensure all paths are relative to the rootPath

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,6 +56,10 @@ function getPaths(
   const nodes = listNodes(rootPath, depthLimit);
   const filterPromise = nodes.then(
     (nodeList) => {
+      //
+      // Ensure paths are resolved against rootPath
+      //
+      nodeList = nodeList.map(fullPath => path.relative(rootPath, fullPath))
       const preFilteredNodes =
         !excludeFilter
         ? nodeList


### PR DESCRIPTION
Hello! Thanks for the lib! I've made a very simple change suggestion:

BREAKING CHANGE
Previously, paths were relative if the question was not provided a rootPath path option and, if provided a rootPath, they became absolute (by including ${rootPath}${relativePath}. This update makes all paths relative, leaving the responsibility of building absolute paths to the consumer.

Reasons for update:
- Make return behavior consistent (always relative) and independent of rootPath option being set
- Improved UI when using rootPath (only the relative portion is shown and search goes only through relative paths)